### PR TITLE
fix index when removing enchantments

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -107,9 +107,13 @@ function addEnchant() {
 }
 
 function removeEnchant() {
-    $(this)
-        .parent()
-        .remove()
+    const enchant = $(this).parent();
+    const enchantments = enchant.parent();
+    enchant.remove();
+    //re-create enchantments index
+    enchantments.children().each((i, elem) => {
+        $(elem).attr('class', `enchant_${i}`);
+    });
 }
 
 function getTool(which) {


### PR DESCRIPTION
In order to mantain consistency with the add/iteration logic the remove operation must ensure that every echantment index is an integer between 0 and total length